### PR TITLE
Windows read only fix

### DIFF
--- a/flips.cpp
+++ b/flips.cpp
@@ -6,10 +6,12 @@
 #include "flips.h"
 #include "crc32.h"
 
-//get rid of dependencies on libstdc++, they eat 200KB on Windows
+#ifndef _WIN32
+//get rid of dependencies on libstdc++
 void* operator new(size_t n) { return malloc(n); } // forget allocation failures, let them segfault.
 void operator delete(void * p) { free(p); }
 extern "C" void __cxa_pure_virtual() { while(1); }
+#endif
 
 
 //TODO: delete
@@ -448,7 +450,8 @@ config::~config()
 	{
 		LPWSTR data = this->flatten();
 //puts(data);
-		filewrite::write(this->filename, (struct mem){ (uint8_t*)data, wcslen(data)*sizeof(WCHAR) });
+		struct mem m = { (uint8_t*)data, wcslen(data)*sizeof(WCHAR) };
+		filewrite::write(this->filename, m);
 		free(data);
 		free(this->filename);
 	}

--- a/flips.cpp
+++ b/flips.cpp
@@ -802,10 +802,16 @@ struct errorinfo ApplyPatchMem(file* patch, LPCWSTR inromname, bool verifyinput,
 		if (update_rom_list) DeleteRomFromList(inromname);
 		return error(el_broken, "Couldn't read ROM. What exactly are you doing?");
 	}
-	struct errorinfo errinf = ApplyPatchMem2(patch, inrom->get(), verifyinput,
-	                                         shouldRemoveHeader(inromname, inrom->len()), outromname, manifestinfo);
-	if (update_rom_list && errinf.level==el_ok) AddToRomList(patch, inromname);
+	
+	// copy inrom and close the file (in case used as outrom as well)
+	struct mem inrom_copy = { (uint8_t*)malloc(inrom->len()), inrom->len() };
+	memcpy(inrom_copy.ptr, inrom->get().ptr, inrom->len());
 	delete inrom;
+	
+	struct errorinfo errinf = ApplyPatchMem2(patch, inrom_copy, verifyinput,
+	                                         shouldRemoveHeader(inromname, inrom_copy.len), outromname, manifestinfo);
+	if (update_rom_list && errinf.level==el_ok) AddToRomList(patch, inromname);
+	free(inrom_copy.ptr);
 	return errinf;
 }
 

--- a/global.h
+++ b/global.h
@@ -48,7 +48,7 @@ public:
 	
 	virtual size_t len() = 0;
 	virtual const uint8_t * ptr() = 0;
-	struct mem get() { return (struct mem){ (uint8_t*)ptr(), len() }; }
+	struct mem get() { struct mem m = { (uint8_t*)ptr(), len() }; return m; }
 	
 	virtual ~filemap() {}
 };

--- a/make.bat
+++ b/make.bat
@@ -31,7 +31,7 @@ rem /openmp
 cl /c /Oy /Oi /Os /Ox /EHs-c- /Gz /D_CRT_SECURE_NO_WARNINGS /WX /wd4700 /nologo /TP /MT /GL /Imsvc ^
    /DUSE_DIVSUFSORT /Ilibdivsufsort-2.0.1\include /DHAVE_CONFIG_H libdivsufsort-2.0.1\lib\*.c ^
    *.c *.cpp
-rc /nologo flips.rc
+rc flips.rc
 
 link /LTCG /nologo *.obj /subsystem:windows flips.res user32.lib gdi32.lib comctl32.lib shell32.lib comdlg32.lib advapi32.lib /out:flips.exe
 


### PR DESCRIPTION
Was receiving a "read-only" error trying to apply a patch directly to a file instead of to another output file.

This change makes a copy of the inrom file data and closes it before proceeding to apply the patch.

The copy itself seems redundant, the problem is an unclosed file, but it was tied to the filemap/file class structure which seems to have to close the file and free its memory in one delete step, so this seemed like a smaller change than trying to adjust the many versions of those classes.

Also a few small syntax/compilation tweaks for MSVC.

A windows build of this is available here:
(link removed)