### PR TITLE
Fix 'Run in emulator' option with mingw-w64 8.1.0

### DIFF
--- a/flips-w32.cpp
+++ b/flips-w32.cpp
@@ -576,13 +576,13 @@ error:
 	if (patchedmem.ptr) free(patchedmem.ptr);
 	
 	WCHAR cmdline[1+MAX_PATH+3+MAX_PATH+1+1];
-	swprintf(cmdline, 1+MAX_PATH+3+MAX_PATH+1+1, TEXT("\"%s\" \"%s\""), st_emulator, outfilename);
+	swprintf(cmdline, 1+MAX_PATH+3+MAX_PATH+1+1, TEXT("\"%ls\" \"%ls\""), st_emulator, outfilename);
 	WCHAR * dirend=GetBaseName(patchpath);
 	if (dirend) *dirend='\0';
 	STARTUPINFO startupinfo;
 	ZeroMemory(&startupinfo, sizeof(STARTUPINFO));
 	PROCESS_INFORMATION processinformation;
-	if (!CreateProcess(st_emulator, cmdline, NULL, NULL, FALSE, 0, NULL, patchpath, &startupinfo, &processinformation))
+	if (!CreateProcess(NULL, cmdline, NULL, NULL, FALSE, 0, NULL, patchpath, &startupinfo, &processinformation))
 	{
 		MessageBoxA(hwndMain, "Couldn't open emulator.", flipsversion, mboxtype[el_broken]);
 		//DeleteFile(tempfilename);


### PR DESCRIPTION
The `swprintf` function takes the `%s` format specifier to mean a `const char*`, so the final output in `cmdline` would be `"C" "C"`. I explicitly specify `%ls` to mean `wchar_t*` and this fixes the issue. I am not sure if this is an issue specifically with mingw-w64 8.1.0, but `%ls` is always correct regardless.

Additionally I removed the emulator path from the first CreateProcess argument since it does not do anything (your command line already contains which process to launch).