### PR TITLE
Add AppVeyor file for CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: appveyor.{build}
+image:
+  - Visual Studio 2017
+  - Ubuntu
+environment:
+  MINGW_DIR: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0
+install:
+  - cmd: set PATH=%MINGW_DIR%\mingw64\bin;%PATH%
+  - sh: sudo apt update
+  - sh: sudo apt -y install libgtk-3-dev
+build_script:
+  - cmd: mingw32-make.exe TARGET=windows CFLAGS=-O3
+  - sh: make


### PR DESCRIPTION
This builds with mingw-w64 on Windows and whatever `make` takes as the default on Ubuntu. Additionally artifacts are created so if you add your project to AppVeyor you can provide an automatic download link for the latest commit hash.

See https://www.appveyor.com/docs/