### PR TITLE
Makefile: Respect the CXX environment variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ FNAME_gtk := flips
 FNAME_windows := flips.exe
 FNAME_cli := flips
 
-CXX = g++
+CXX ?= g++
 
 XFILES :=
 


### PR DESCRIPTION
This allows overriding `CXX` with an environment variable so that I can build flips with `clang++` instead of `g++`.

Warning this exposes a new issue when build with `clang-8.0.0`.
```
clang-8: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
```
I tested this with one sfc patch and found it created identical files when built with `g++` and `clang++`.