### PR TITLE
Add `extern C` blocks to `libips.h` and `libups.h`

### DIFF
--- a/libips.h
+++ b/libips.h
@@ -5,6 +5,10 @@
 
 #include "global.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum ipserror {
 	ips_ok,//Patch applied or created successfully.
 	
@@ -39,3 +43,8 @@ void ips_free(struct mem mem);
 struct ipsstudy;
 enum ipserror ips_study(struct mem patch, struct ipsstudy * study);
 enum ipserror ips_apply_study(struct mem patch, struct ipsstudy * study, struct mem in, struct mem * out);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/libups.h
+++ b/libups.h
@@ -5,6 +5,10 @@
 
 #include "global.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //Several of those are unused, but remain there so the remaining ones match bpserror.
 enum upserror {
 	ups_ok,//Patch applied or created successfully.
@@ -33,3 +37,8 @@ enum upserror ups_create(struct mem source, struct mem target, struct mem * patc
 //  input, nor on anything you got from anywhere else. ups_free is guaranteed to be equivalent to
 //  calling stdlib.h's free() on mem.ptr.
 void ups_free(struct mem mem);
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Hi !

I'm writing Rust bindings to `libups`, `libips`, and `libbps` for Rust using the Flips code, and I noticed that while you can link to `libbps`, you couldn't link to the other two being compiled as standalone libraries because of missing `extern "C" {}` blocks in the header.

This PR fixes that!