### PR TITLE
flatpak: Allow saving in home and SDK bump

### DIFF
--- a/flatpak/com.github.Alcaro.Flips.json
+++ b/flatpak/com.github.Alcaro.Flips.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.Alcaro.Flips",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.34",
+    "runtime-version" : "3.38",
     "sdk" : "org.gnome.Sdk",
     "command" : "flips",
     "finish-args" : [

--- a/flatpak/com.github.Alcaro.Flips.json
+++ b/flatpak/com.github.Alcaro.Flips.json
@@ -12,6 +12,8 @@
         "--socket=wayland",
         /* OpenGL + DRI access */
         "--device=dri",
+        /* Needed to save patched ROMs */
+        "--filesystem=home",
         /* Needed to find the ROMs and patches */
         "--filesystem=host:ro"
     ],


### PR DESCRIPTION
Allow saving the patched ROMs in the home directory and bump to the freshly released 3.38 GNOME SDK (the 3.34 one is EOL).

If you accept these changes, I'll take care of pushing them to Flathub.