### PR TITLE
build: Makefile improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ endif
 
 MOREFLAGS := $(CFLAGS_$(TARGET))
 
-
 DIVSUF := libdivsufsort-2.0.1
 SOURCES += $(DIVSUF)/lib/divsufsort.c $(DIVSUF)/lib/sssort.c $(DIVSUF)/lib/trsort.c
 MOREFLAGS += -I$(DIVSUF)/include -DHAVE_CONFIG_H -D__STDC_FORMAT_MACROS
@@ -94,7 +93,7 @@ ifeq ($(CFLAGS),-g)
 endif
 
 ifeq ($(TARGET),gtk)
-install:
+install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ XFILES :=
 SOURCES := $(SRCDIR)/*.cpp
 
 PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+DATAROOTDIR ?= $(PREFIX)/share
+DATADIR ?= $(DATAROOTDIR)
 
 ifeq ($(TARGET),win)
   override TARGET := windows
@@ -96,21 +99,21 @@ endif
 
 ifeq ($(TARGET),gtk)
 install: all
-	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps
-	mkdir -p $(DESTDIR)$(PREFIX)/share/metainfo
-	install -p -m755 $(FNAME_$(TARGET)) $(DESTDIR)$(PREFIX)/bin
-	install -p -m755 $(SRCDIR)/data/com.github.Alcaro.Flips.desktop $(DESTDIR)$(PREFIX)/share/applications
-	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
-	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips-symbolic.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps
-	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/applications
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/scalable/apps
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/symbolic/apps
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/metainfo
+	install -p -m755 $(FNAME_$(TARGET)) $(DESTDIR)$(BINDIR)
+	install -p -m755 $(SRCDIR)/data/com.github.Alcaro.Flips.desktop $(DESTDIR)$(DATAROOTDIR)/applications
+	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.svg $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/scalable/apps
+	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips-symbolic.svg $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/symbolic/apps
+	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.metainfo.xml $(DESTDIR)$(DATAROOTDIR)/metainfo
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/$(FNAME_$(TARGET))
-	rm -f $(DESTDIR)$(PREFIX)/share/applications/com.github.Alcaro.Flips.desktop
-	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/com.github.Alcaro.Flips.svg
-	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps/com.github.Alcaro.Flips-symbolic.svg
-	rm -f $(DESTDIR)$(PREFIX)/share/metainfo/com.github.Alcaro.Flips.metainfo.xml
+	rm -f $(DESTDIR)$(BINDIR)/$(FNAME_$(TARGET))
+	rm -f $(DESTDIR)$(DATAROOTDIR)/applications/com.github.Alcaro.Flips.desktop
+	rm -f $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/scalable/apps/com.github.Alcaro.Flips.svg
+	rm -f $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/symbolic/apps/com.github.Alcaro.Flips-symbolic.svg
+	rm -f $(DESTDIR)$(DATAROOTDIR)/metainfo/com.github.Alcaro.Flips.metainfo.xml
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 #This script creates a debug-optimized binary by default. If you're on Linux, you'll get a faster binary from make.sh.
 
+SRCDIR := $(abspath $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST))))))
+
 CFLAGS_gtk = -DFLIPS_GTK $(GTKFLAGS) $(GTKLIBS)
 CFLAGS_windows := -DFLIPS_WINDOWS -mwindows -lgdi32 -lcomdlg32 -lcomctl32 -luser32 -lkernel32 -lshell32 -ladvapi32
 CFLAGS_cli := -DFLIPS_CLI
@@ -15,7 +17,7 @@ CFLAGS ?= -g
 
 XFILES :=
 
-SOURCES := *.cpp
+SOURCES := $(SRCDIR)/*.cpp
 
 PREFIX ?= /usr
 
@@ -78,7 +80,7 @@ endif
 
 MOREFLAGS := $(CFLAGS_$(TARGET))
 
-DIVSUF := libdivsufsort-2.0.1
+DIVSUF := $(SRCDIR)/libdivsufsort-2.0.1
 SOURCES += $(DIVSUF)/lib/divsufsort.c $(DIVSUF)/lib/sssort.c $(DIVSUF)/lib/trsort.c
 MOREFLAGS += -I$(DIVSUF)/include -DHAVE_CONFIG_H -D__STDC_FORMAT_MACROS
 
@@ -100,10 +102,10 @@ install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps
 	mkdir -p $(DESTDIR)$(PREFIX)/share/metainfo
 	install -p -m755 $(FNAME_$(TARGET)) $(DESTDIR)$(PREFIX)/bin
-	install -p -m755 data/com.github.Alcaro.Flips.desktop $(DESTDIR)$(PREFIX)/share/applications
-	install -p -m644 data/com.github.Alcaro.Flips.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
-	install -p -m644 data/com.github.Alcaro.Flips-symbolic.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps
-	install -p -m644 data/com.github.Alcaro.Flips.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo
+	install -p -m755 $(SRCDIR)/data/com.github.Alcaro.Flips.desktop $(DESTDIR)$(PREFIX)/share/applications
+	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
+	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips-symbolic.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps
+	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo
 
 uninstall:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -108,14 +108,9 @@ install: all
 	install -p -m644 $(SRCDIR)/data/com.github.Alcaro.Flips.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo
 
 uninstall:
-	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps
-	mkdir -p $(DESTDIR)$(PREFIX)/share/metainfo
-	rm $(DESTDIR)$(PREFIX)/bin/$(FNAME_$(TARGET))
-	rm $(DESTDIR)$(PREFIX)/share/applications/com.github.Alcaro.Flips.desktop
-	rm $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/com.github.Alcaro.Flips.svg
-	rm $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps/com.github.Alcaro.Flips-symbolic.svg
-	rm $(DESTDIR)$(PREFIX)/share/metainfo/com.github.Alcaro.Flips.metainfo.xml
+	rm -f $(DESTDIR)$(PREFIX)/bin/$(FNAME_$(TARGET))
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/com.github.Alcaro.Flips.desktop
+	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/com.github.Alcaro.Flips.svg
+	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps/com.github.Alcaro.Flips-symbolic.svg
+	rm -f $(DESTDIR)$(PREFIX)/share/metainfo/com.github.Alcaro.Flips.metainfo.xml
 endif


### PR DESCRIPTION
This has various makefile usability improvements.

* The `install` target now depends on the `all` target so that the user can just type `make install` instead of `make; make install`.
* This uses a GNU make command to dynamically create the `$(SRCDIR)` variable so that the user can build out of tree. See the below example.
* This fixes the uninstall target by removing the bogus `mkdir(1)` commands and adding `-f` to for the `rm(1)` commands so that `make uninstall` does not fail if any of the files were manually removed prior. If the files does not exist then they won't be removed and no harm will be done.
* This adds `$(BINDIR)` and `$(DATAROOTDIR)`. I also added `$(DATADIR)` to be complete with the GNU install directories even if its not currently all that useful for Flips.

Out of tree build example:
```
mkdir -p /tmp/build
cd /tmp/build
make install -f /path/to/Flips/Makefile
```