### PR TITLE
include marcrobledo's RomPatcher.js in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Third-party forks, or separate tools, covering usecases this version doesn't (th
 - [MultiPatch](https://projects.sappharad.com/tools/multipatch.html), OSX, applies BPS/IPS/UPS/PPF/Xdelta/bsdiff/Ninja2, creates BPS/IPS/XDelta/bsdiff
 - [QtFloatingIPS](https://github.com/covarianttensor/QtFloatingIPS), Flips port to OSX (may work on others too)
 - [Wh0ba Floating IPS](https://wh0ba.github.io/repo/), Flips port to iOS/Cydia
+- [RomPatcher.js](https://github.com/marcrobledo/RomPatcher.js), JavaScript, applies APS/BPS/IPS/PPF/RUP/UPS/Xdelta, creates APS/BPS/IPS/RUP/UPS
 - [CPS](https://media.smwcentral.net/Alcaro/bps/), JavaScript, applies BPS, creates nothing
 - There are many tools that offer a strict subset of Flips functionality (Lunar IPS, beat, etc). I'm not listing them here.
 


### PR DESCRIPTION
> it's fairly fast, browser-based, and supports all the main ones. also rm's/adds headers to ur rom if it makes the patch work, and provides checksums.

i thought that there should be a good browser solution listed; and if this were in the readme a week ago, it wouldnt have taken me a week to patch a smw rom on a chromebook. there are no other changes than to the readme.