### PR TITLE
Add GH Actions CI for debug builds

### DIFF
--- a/.github/workflows/build-unoptimized.yml
+++ b/.github/workflows/build-unoptimized.yml
@@ -1,0 +1,46 @@
+name: Build unoptimized
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  linux:
+    strategy:
+     matrix:
+        target: ['gtk', 'cli']
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Dependencies
+      run: sudo apt -y install libgtk-3-dev
+    - name: Make target ${{ matrix.target }}
+      run: TARGET=${{ matrix.target }} make
+
+  macos:
+    strategy:
+     matrix:
+        target: ['gtk', 'cli']
+    runs-on: macos-latest
+    steps:
+     - uses: actions/checkout@v4
+     - name: Dependencies
+       run: brew install gtk+3 libomp llvm
+     - name: Make target ${{ matrix.target }}
+       # Using brew's llvm, because apple's does not support -fopenmp
+       run: CXX=/opt/homebrew/opt/llvm/bin/clang++ TARGET=${{ matrix.target }} make
+
+  windows:
+    strategy:
+     matrix:
+        target: ['windows', 'cli']
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      # TODO: build using MSVC. It currently errors and warns on a whole bunch of stuff
+      # Also yes, that requires either shenanigans or a seperate action. - uses: ilammy/msvc-dev-cmd@v1
+      - name: Make target ${{ matrix.target }}
+        run:  $env:TARGET='${{ matrix.target }}'; make


### PR DESCRIPTION
Currently this gets triggered on
- new push on master
- a PR that targets master
- when manually triggered from the actions menu from someone with perms.

All OS build their GUI and CLI without any optimizations.
Linux uses g++ to build. macos uses a modified clang++ to build in order to get around -fopenmp erroring. Windows uses g++ because MSVC throws errors and warnings out like crazy ( See https://github.com/Miepee/Flips/actions/runs/9196713315/job/25295435231 if you want to see the full log of those )

Macos currently on purpose targets macos-13 instead of macos-latest, as macos-latest is ARM-only, while macos-13 is stil using x64_86 which means it'll run on both intel macs and m1 macs via rosetta.


Helps addressing more things from #56 