### PR TITLE
Build optimized Linux artifacts

### DIFF
--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -1,0 +1,22 @@
+name: Build optimized
+
+on:
+  workflow_dispatch:
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: ghcr.io/pyca/cryptography-manylinux_2_28:x86_64
+    steps:
+    - uses: actions/checkout@v4
+    - name: Dependencies
+      run: dnf install -y gtk3-devel zip
+    - name: Build
+      run: ./make.sh
+    - name: Zip to Archive
+      run: zip -9 ./linux-x64.zip ./flips
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: linux-x64-gui.zip
+        path: ./linux-x64.zip


### PR DESCRIPTION
I'm seperating the optimized builds into seperate PRs, as I'm expecting a bit more discussion on them.

This PR builds release linux versions and uploads them as artifacts. It does so in a linux docker container with a very old GLIBC in order to ensure that the built flips is compatible with as many linux distros as possible. This does not create any release.

Currently the workflow can only be run manually and does not run automatically.