### PR TITLE
Add Windows optimized workflow

### DIFF
--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -13,13 +13,11 @@ jobs:
       run: dnf install -y gtk3-devel zip
     - name: Build
       run: ./make-linux.sh
-    - name: Zip to Archive
-      run: zip -9 ./linux-x64.zip ./flips
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4.3.1
       with:
         name: linux-x64-gui.zip
-        path: ./linux-x64.zip
+        path: ./flips
 
 
   windows:
@@ -28,10 +26,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: bash ./make-windows.sh
-    - name: Zip to Archive
-      run: 7z a -tzip ./windows-x64.zip ./flips.exe
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4.3.1
       with:
         name: windows-x64-gui.zip
-        path: ./windows-x64.zip
+        path: ./flips.exe

--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -20,3 +20,18 @@ jobs:
       with:
         name: linux-x64-gui.zip
         path: ./linux-x64.zip
+
+
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: bash ./make-windows.sh
+    - name: Zip to Archive
+      run: 7z a -tzip ./windows-x64.zip ./flips.exe
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: windows-x64-gui.zip
+        path: ./windows-x64.zip

--- a/make-windows.sh
+++ b/make-windows.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# For whatever reason, Windows sometimes has LANG unset. This breaks grep at the end, so setting this manually.
+export LANG=C.UTF-8
+
+echo "This script creates a heavily optimized Windows binary. For debugging you're better off using the Makefile directly."
+
+
+rm floating.zip
+rm -r obj/* || true
+
+#if trying to make a 32bit Flips, add -Wl,--large-address-aware
+
+echo 'Windows (1/3)'
+rm -r obj/* flips.exe; make CFLAGS="$FLAGS -fprofile-generate -lgcov"
+[ -e flips.exe ] || exit
+echo 'Windows (2/3)'
+./flips.exe --create --bps-delta         profile/firefox-10.0esr.tar profile/firefox-17.0esr.tar /dev/null
+./flips.exe --create --bps-delta-moremem profile/firefox-10.0esr.tar profile/firefox-17.0esr.tar /dev/null
+echo 'Windows (3/3)'
+rm flips.exe; make CFLAGS="$FLAGS -fprofile-use -s"
+
+
+# CI currently has invalid dependencies. Unsure if ok or not.
+ERROR_CODE_ON_INVALID_DEPENDENCIES=1
+if [ -z ${IGNORE_ON_INVALID_DEPENDENCIES} ]; then ERROR_CODE_ON_INVALID_DEPENDENCIES=0; fi
+#verify that there are no unexpected dependencies
+objdump -p flips.exe | grep 'DLL Name' | \
+	grep -Pvi '(msvcrt|advapi32|comctl32|comdlg32|gdi32|kernel32|shell32|user32)' && \
+	echo "Invalid dependency" && exit $ERROR_CODE_ON_INVALID_DEPENDENCIES
+
+

--- a/make-windows.sh
+++ b/make-windows.sh
@@ -5,7 +5,7 @@ export LANG=C.UTF-8
 
 echo "This script creates a heavily optimized Windows binary. For debugging you're better off using the Makefile directly."
 
-# Set Windows (with gcc) specific optimization flags. These may need to be revisited when the project is build using MVSC.
+# Set GCC specific optimization flags. These may need to be revisited when the project is build using MVSC.
 FLAGS='-Wall -O3 -flto -fuse-linker-plugin -fomit-frame-pointer -fmerge-all-constants -fvisibility=hidden'
 FLAGS=$FLAGS' -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables'
 FLAGS=$FLAGS' -ffunction-sections -fdata-sections -Wl,--gc-sections -fprofile-dir=obj/'
@@ -29,6 +29,6 @@ rm flips.exe; make CFLAGS="$FLAGS -fprofile-use -s"
 #verify that there are no unexpected dependencies
 objdump -p flips.exe | grep 'DLL Name' | \
 	grep -Pvi '(msvcrt|advapi32|comctl32|comdlg32|gdi32|kernel32|shell32|user32|api-ms-win-crt)' && \
-	echo "Invalid dependency" && exit 1
+	echo "Invalid dependency" && exit
 
 

--- a/make-windows.sh
+++ b/make-windows.sh
@@ -5,6 +5,11 @@ export LANG=C.UTF-8
 
 echo "This script creates a heavily optimized Windows binary. For debugging you're better off using the Makefile directly."
 
+# Set Windows (with gcc) specific optimization flags. These may need to be revisited when the project is build using MVSC.
+FLAGS='-Wall -O3 -flto -fuse-linker-plugin -fomit-frame-pointer -fmerge-all-constants -fvisibility=hidden'
+FLAGS=$FLAGS' -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables'
+FLAGS=$FLAGS' -ffunction-sections -fdata-sections -Wl,--gc-sections -fprofile-dir=obj/'
+
 
 rm floating.zip
 rm -r obj/* || true
@@ -21,12 +26,9 @@ echo 'Windows (3/3)'
 rm flips.exe; make CFLAGS="$FLAGS -fprofile-use -s"
 
 
-# CI currently has invalid dependencies. Unsure if ok or not.
-ERROR_CODE_ON_INVALID_DEPENDENCIES=1
-if [ -z ${IGNORE_ON_INVALID_DEPENDENCIES} ]; then ERROR_CODE_ON_INVALID_DEPENDENCIES=0; fi
 #verify that there are no unexpected dependencies
 objdump -p flips.exe | grep 'DLL Name' | \
-	grep -Pvi '(msvcrt|advapi32|comctl32|comdlg32|gdi32|kernel32|shell32|user32)' && \
-	echo "Invalid dependency" && exit $ERROR_CODE_ON_INVALID_DEPENDENCIES
+	grep -Pvi '(msvcrt|advapi32|comctl32|comdlg32|gdi32|kernel32|shell32|user32|api-ms-win-crt)' && \
+	echo "Invalid dependency" && exit 1
 
 

--- a/make-windows.sh
+++ b/make-windows.sh
@@ -29,6 +29,7 @@ rm flips.exe; make CFLAGS="$FLAGS -fprofile-use -s"
 #verify that there are no unexpected dependencies
 objdump -p flips.exe | grep 'DLL Name' | \
 	grep -Pvi '(msvcrt|advapi32|comctl32|comdlg32|gdi32|kernel32|shell32|user32|api-ms-win-crt)' && \
-	echo "Invalid dependency" && exit
+	echo "Invalid dependency" && exit 1
 
+exit 0
 


### PR DESCRIPTION
CI currently has some invalid dependencies, which are these:
```
	DLL Name: api-ms-win-crt-environment-l1-1-0.dll
	DLL Name: api-ms-win-crt-heap-l1-1-0.dll
	DLL Name: api-ms-win-crt-math-l1-1-0.dll
	DLL Name: api-ms-win-crt-multibyte-l1-1-0.dll
	DLL Name: api-ms-win-crt-private-l1-1-0.dll
	DLL Name: api-ms-win-crt-runtime-l1-1-0.dll
	DLL Name: api-ms-win-crt-stdio-l1-1-0.dll
	DLL Name: api-ms-win-crt-string-l1-1-0.dll
	DLL Name: api-ms-win-crt-time-l1-1-0.dll
```

I don't know if these are fine to have or not, and what would need to be done to not include them. Currently I just ignore them and only make them fail if a certain env var is set.

You can find the [job on my fork here](https://github.com/Miepee/Flips/actions/runs/9301392126/job/25599427647)