### PR TITLE
Add macos optimzed workflow

### DIFF
--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -19,7 +19,6 @@ jobs:
         name: linux-x64-gui.zip
         path: ./flips
 
-
   windows:
     runs-on: windows-latest
     steps:
@@ -31,3 +30,17 @@ jobs:
       with:
         name: windows-x64-gui.zip
         path: ./flips.exe
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Dependencies
+      run: brew install gtk+3 libomp llvm
+    - name: Build
+      run: CXX=/opt/homebrew/opt/llvm/bin/clang++ TARGET=gtk ./make-macos.sh
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: macos-m1-gui.zip
+        path: ./flips

--- a/make-macos.sh
+++ b/make-macos.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+echo "This script creates a heavily optimized Macos binary. For debugging, you're better off using the Makefile directly."
+
+FLAGS='-Wall -O3 -flto -fomit-frame-pointer -fmerge-all-constants -fvisibility=hidden'
+FLAGS=$FLAGS' -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables'
+FLAGS=$FLAGS' -ffunction-sections -fdata-sections'
+
+PROFILE=yes
+
+for i in "$@"; do
+case "$i" in
+  --harden=yes)
+    FLAGS=$FLAGS' -fstack-protector-strong -pie -fPIE'
+  ;;
+  --profile=no|--profile=no-once)
+    # With PGO, compilation takes about 75 seconds for me, with a peak memory use of 814MB.
+    # Without PGO, it takes 2.5 seconds and 75MB RAM. However, the resulting binary is about 2% slower.
+    PROFILE=no
+  ;;
+  --cflags=*|--lflags=*)
+    FLAGS=$FLAGS" ${i#*=}"
+  ;;
+  --harden=no|--profile=yes)
+  ;;
+  *)
+  echo "Unknown argument $1; valid arguments are:"
+  echo "--harden=yes --profile=no --cflags=(...) --lflags=(...) --install=yes"
+  exit 1
+  ;;
+esac
+done
+
+if [ $PROFILE = yes ]; then
+
+echo 'GTK+ (1/3)'
+rm obj/* flips; make CFLAGS="$FLAGS -fprofile-generate=obj/" || exit $?
+[ -e flips ] || exit 1
+
+echo 'GTK+ (2/3)'
+# These files are downloaded and extracted from
+# https://ftp.mozilla.org/pub/firefox/releases/10.0esr/linux-x86_64/en-US/firefox-10.0esr.tar.bz2
+# https://ftp.mozilla.org/pub/firefox/releases/17.0esr/linux-x86_64/en-US/firefox-17.0esr.tar.bz2
+if [ -x /usr/bin/time ]; then
+TIME='/usr/bin/time'
+else
+TIME=''
+fi
+export OMP_NUM_THREADS=1 # -fprofile-generate isn't thread safe
+$TIME ./flips --create --bps-delta         profile/firefox-10.0esr.tar profile/firefox-17.0esr.tar /dev/null
+$TIME ./flips --create --bps-delta-moremem profile/firefox-10.0esr.tar profile/firefox-17.0esr.tar /dev/null
+
+echo 'GTK+ (3/3)'
+
+# FIXME: Currently this path is hardcoded for CI. May or may not be different on real machines.
+/opt/homebrew/opt/llvm/bin/llvm-profdata merge -o default.profdata ./obj/*.profraw
+
+rm flips; make CFLAGS="$FLAGS -fprofile-use" || exit $?
+else
+rm flips; make CFLAGS="$FLAGS" || exit $?
+fi


### PR DESCRIPTION
- Originally I wanted to build CI all on macos-13 because that one's x64+arm, but turns out we get some linker warnings which probably cause flips runtime errors, so arm only it is.
- macos doesnt ship llvm-profdata by default, so I just hardcode the path to homebrew instead. Added a fixme, in case anyone who cares more about macos than me wants to fix it
- Link to job [can be found on my fork](https://github.com/Miepee/Flips/actions/runs/9303373637/job/25605528627)
