### PR TITLE
Automatically create releases

### DIFF
--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -2,6 +2,9 @@ name: Build optimized
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   linux:
@@ -44,3 +47,32 @@ jobs:
       with:
         name: macos-m1-gui.zip
         path: ./flips
+
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [linux, windows, macos]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Download binaries
+      uses: actions/download-artifact@v4
+      with:
+        path: builds/
+    - name: Find Flips version
+      id: flips_version
+      run: echo version=$(git rev-list --count master) >> $GITHUB_OUTPUT
+    - name: Create zips
+      run: |
+        zip -9 ./flips-linux.zip ./builds/linux-x64-gui.zip/flips
+        zip -9 ./flips-windows.zip ./builds/windows-x64-gui.zip/flips.exe
+        zip -9 ./flips-macos.zip ./builds/macos-m1-gui.zip/flips
+    - name: Upload GitHub Release
+      uses: svenstaro/upload-release-action@2.9.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: flips-*.zip
+        file_glob: true
+        tag: v${{ steps.flips_version.outputs.version }}
+        body: "A release of commit ${{ github.sha }}."

--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         zip -9 ./flips-linux.zip ./builds/linux-x64-gui.zip/flips
         zip -9 ./flips-windows.zip ./builds/windows-x64-gui.zip/flips.exe
-        zip -9 ./flips-macos.zip ./builds/macos-m1-gui.zip/flips
+        #zip -9 ./flips-macos.zip ./builds/macos-m1-gui.zip/flips
     - name: Upload GitHub Release
       uses: svenstaro/upload-release-action@2.9.0
       with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features:
 - Can remembers which ROMs you've used, and use them again if it thinks it's correct (BPS only, GUI only)
 - Can launch other programs after patching the ROMs; together with the above, this allows you to double click a BPS to launch an emulator (GUI only)
 
-Floating IPS is in maintenance mode. Bug reports and pull requests will be read, but feature requests are unlikely to be implemented. There will be no formal releases within any forseeable future; every commit should be considered a release. If you need a version number, use the commit count.
+Floating IPS is in maintenance mode. Bug reports and pull requests will be read, but feature requests are unlikely to be implemented. Releases are automated for every commit, meaning the release schedule is highly erratic.
 
 Third-party forks, or separate tools, covering usecases this version doesn't (this only acknowledges their existence, and is not an endorsement; I haven't used most of them):
 - [Floating IPS](https://github.com/Alcaro/Flips); the original Floating IPS, in case you're currently looking at a fork


### PR DESCRIPTION
This automatically creates a release for each commit done on the `master` branch

This runs after the optimized builds for win/lin/mac have been created.


The tag and release title is `v{AMOUNT-OF-COMMITS}`
The body just lists the commit.

![grafik](https://github.com/Alcaro/Flips/assets/38186597/d66ed0ac-8239-4ed9-8fb8-6824ba3b79d1)


This *should* work ootb for you with no need to do any repo configuration.

If you want a different release title/body, lemme know, I'm very uncreative in regards to that.

Fixes #56 