### PR TITLE
Build debug builds with mvsc

### DIFF
--- a/.github/workflows/build-unoptimized.yml
+++ b/.github/workflows/build-unoptimized.yml
@@ -40,7 +40,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      # TODO: build using MSVC. It currently errors and warns on a whole bunch of stuff
-      # Also yes, that requires either shenanigans or a seperate action. - uses: ilammy/msvc-dev-cmd@v1
+      # Build using MSVC. It currently warns on a bit of stuff because apparently -Wall warns on basically everything
+      # Also yes, using mvsc requires either shenanigans or a seperate action.
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Make target ${{ matrix.target }}
-        run:  $env:TARGET='${{ matrix.target }}'; make
+        run:  $env:CXX='cl.exe'; $env:TARGET='${{ matrix.target }}'; make

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@
 SRCDIR := $(abspath $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST))))))
 
 CFLAGS_gtk = -DFLIPS_GTK $(GTKFLAGS) $(GTKLIBS)
-CFLAGS_windows := -DFLIPS_WINDOWS -mwindows -lgdi32 -lcomdlg32 -lcomctl32 -luser32 -lkernel32 -lshell32 -ladvapi32
+CFLAGS_windows_base := -DFLIPS_WINDOWS
+CFLAGS_windows_gcc := -mwindows -lgdi32 -lcomdlg32 -lcomctl32 -luser32 -lkernel32 -lshell32 -ladvapi32
+CFLAGS_windows := $(CFLAGS_windows_base) $(CFLAGS_windows_gcc)
+LFLAGS_windows_msvc := gdi32.lib comdlg32.lib comctl32.lib user32.lib kernel32.lib shell32.lib advapi32.lib
 CFLAGS_cli := -DFLIPS_CLI
 
 CFLAGS_G = -fno-rtti -fno-exceptions -DNDEBUG -Wall
@@ -50,6 +53,14 @@ ifeq ($(TARGET),)
   else
     TARGET := gtk
   endif
+endif
+
+ifeq ($(TARGET),windows)
+  ifneq (,$(filter $(CXX),cl cl.exe))
+    override CFLAGS_windows := $(CFLAGS_windows_base)
+    LFLAGS += $(LFLAGS_windows_msvc)
+  endif
+
 endif
 
 ifeq ($(TARGET),gtk)


### PR DESCRIPTION
Fixes #77 
Fixes #20 

I opted to *not* build release builds with MVSC because I'm not particularly in the mood right now to figure out all the equivalent compiler optimizations or how to make mvsc behave with PGO.

No clue if MVSC would even produce faster builds than GCC there.

Does what it's meant to do tho - ensure that source code doesn't have any GCC/Clang specific stuff.