### PR TITLE
flatpak: Update the manifest

### DIFF
--- a/flatpak/com.github.Alcaro.Flips.json
+++ b/flatpak/com.github.Alcaro.Flips.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.Alcaro.Flips",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "command" : "flips",
     "finish-args" : [
@@ -22,13 +22,14 @@
             "name" : "flips",
             "buildsystem" : "simple",
             "build-commands": [
-                "sh make.sh",
+                "sh make-linux.sh --cflags=-DFLATPAK",
                 "make install PREFIX=/app"
             ],
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://github.com/Alcaro/Flips.git"
+                    "url" : "https://github.com/Alcaro/Flips.git",
+                    "branch" : "master"
                 }
             ]
         }


### PR DESCRIPTION
This makes the manifest use the SDK's master branch, updates the build rules, and explicits to build Flips' master branch.